### PR TITLE
Avoid E802

### DIFF
--- a/autoload/loupe/private.vim
+++ b/autoload/loupe/private.vim
@@ -79,7 +79,7 @@ function! loupe#private#clear_highlight() abort
   if exists('w:loupe_hlmatch')
     try
       call matchdelete(w:loupe_hlmatch)
-    catch /\v<E803>/
+    catch /\v<(E802|E803)>/
       " https://github.com/wincent/loupe/issues/1
     finally
       unlet w:loupe_hlmatch


### PR DESCRIPTION
Similar to 156f62c3, we are not entirely sure why this might happen, but
the cost of guarding against it is low. `:h E802` and `:h E803` bring up
the same section, so the root cause is likely similar or the same.

I decided to use a more verbose regex than necessary to make it easier
to search for this line in the code.

Fixes #1
