### PR TITLE
Transient hlsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,18 @@ Controls whether the match's line is vertically centered within the window when 
 let g:LoupeCenterResults=0
 ```
 
+<p align="right"><a name="gloupehlsearchtimeout" href="#user-content-gloupehlsearchtimeout"><code>g:LoupeHlSearchTimeout</code></a></p>
+### `g:LoupeHlSearchTimeout` (number, default: 0)<a name="loupe-gloupehlsearchtimeout-number-default-0" href="#user-content-loupe-gloupehlsearchtimeout-number-default-0"></a>
+
+  " In milliseconds.
+  " To enable this feature, set to a number > 0:
+
+Controls how long (in milliseconds) hlsearch remains active after a search (<strong>`/`</strong>, <strong>`?`</strong>) is executed or a jump (<strong>`n`</strong>, <strong>`*`</strong> etc.) is performed. By default, there is no timeout. Setting this option to a positive number will enable the timeout if timers are supported (i.e. <strong>`has('timers')`</strong>).
+
+```
+let g:LoupeHlSearchTimeout=1000
+```
+
 ## Functions<a name="loupe-functions" href="#user-content-loupe-functions"></a>
 
 <p align="right"><a name="loupehlmatch" href="#user-content-loupehlmatch"><code>loupe#hlmatch()</code></a></p>

--- a/autoload/loupe.vim
+++ b/autoload/loupe.vim
@@ -41,3 +41,29 @@ function! loupe#hlmatch() abort
     let w:loupe_hlmatch=matchadd(l:highlight, l:pattern)
   endif
 endfunction
+
+""
+" @function loupe#hlsearch
+"
+" Make hlsearch transient.
+"
+function! loupe#hlsearch() abort
+  ""
+  " @option g:LoupeHlSearchTimeout number 0
+  " How long after a search command before hlsearch is deactivated.
+  " In milliseconds.
+  " To enable this feature, set to a number > 0:
+  "
+  " ```
+  " let g:LoupeHlSearchTimeout=1000
+  " ```
+  let l:time=get(g:, 'LoupeHlSearchTimeout', 0)
+
+  if l:time > 0 && has('timers')
+    " activate hlsearch
+    set hlsearch
+
+    " schedule hlsearch deactivation
+    let w:hlsearch_timer=timer_start(l:time, 'loupe#private#clear_hlsearch')
+  endif
+endfunction

--- a/autoload/loupe.vim
+++ b/autoload/loupe.vim
@@ -64,6 +64,6 @@ function! loupe#hlsearch() abort
     set hlsearch
 
     " schedule hlsearch deactivation
-    let w:hlsearch_timer=timer_start(l:time, 'loupe#private#clear_hlsearch')
+    let g:hlsearch_timer=timer_start(l:time, 'loupe#private#clear_hlsearch')
   endif
 endfunction

--- a/autoload/loupe/private.vim
+++ b/autoload/loupe/private.vim
@@ -93,7 +93,7 @@ endfunction
 " recent search command.
 function! loupe#private#clear_hlsearch(timer) abort
   " only process the most recent timer
-  if a:timer == w:hlsearch_timer
+  if a:timer == g:hlsearch_timer
     set nohlsearch
   endif
 endfunction

--- a/autoload/loupe/private.vim
+++ b/autoload/loupe/private.vim
@@ -70,7 +70,7 @@ function! loupe#private#prepare_highlight(result) abort
   if has('autocmd')
     augroup LoupeHightlightMatch
       autocmd!
-      autocmd CursorMoved * :call loupe#hlmatch()
+      autocmd CursorMoved * :call loupe#hlmatch() | :call loupe#hlsearch()
     augroup END
   endif
   return a:result
@@ -86,6 +86,15 @@ function! loupe#private#clear_highlight() abort
     finally
       unlet w:loupe_hlmatch
     endtry
+  endif
+endfunction
+
+" Deactivate hlsearch once the configured timeout has passed since the most
+" recent search command.
+function! loupe#private#clear_hlsearch(timer) abort
+  " only process the most recent timer
+  if a:timer == w:hlsearch_timer
+    set nohlsearch
   endif
 endfunction
 

--- a/doc/loupe.txt
+++ b/doc/loupe.txt
@@ -203,6 +203,17 @@ when jumping (via |n|, |N| etc). To disable, set to 0:
 >
     let g:LoupeCenterResults=0
 <
+
+                                                        *g:LoupeHlSearchTimeout*
+|g:LoupeHlSearchTimeout|                                     number (default: 0)
+
+Controls how long (in milliseconds) hlsearch remains active after a search
+(|/|, |?|) is executed or a jump (|n|, |*| etc.) is performed. By default,
+there is no timeout. Setting this option to a positive number will enable the
+timeout if timers are supported.
+>
+    let g:LoupeHlSearchTimeout=1000
+<
 FUNCTIONS                                                      *loupe-functions*
 
 loupe#hlmatch()                                                *loupe#hlmatch()*

--- a/doc/loupe.txt
+++ b/doc/loupe.txt
@@ -208,7 +208,7 @@ when jumping (via |n|, |N| etc). To disable, set to 0:
 |g:LoupeHlSearchTimeout|                                     number (default: 0)
 
 Controls how long (in milliseconds) hlsearch remains active after a search
-(|/|, |?|) is executed or a jump (|n|, |*| etc.) is performed. By default,
+(|/|, |?|) is executed or a jump (|n|, |star| etc.) is performed. By default,
 there is no timeout. Setting this option to a positive number will enable the
 timeout if timers are supported.
 >

--- a/plugin/loupe.vim
+++ b/plugin/loupe.vim
@@ -434,7 +434,8 @@ function! s:map(keys, name)
         \ a:keys .
         \ 'zv' .
         \ s:center_string .
-        \ ':call loupe#hlmatch()<CR>'
+        \ ':call loupe#hlmatch()<CR>' .
+        \ ':call loupe#hlsearch()<CR>'
 endfunction
 
 ""


### PR DESCRIPTION
### Why

It would be nice to be able to make `'hlsearch'` automatically dissipate after a configured timeout period, leaving only the match under the cursor highlighted.

### Demo

[![asciicast](https://asciinema.org/a/yji8RsBfgIART7GX0qXQG3gSf.png)](https://asciinema.org/a/yji8RsBfgIART7GX0qXQG3gSf?autoplay=1&loop=1)

### How

This feature is off by default and can be activated by setting `g:LoupeHlSearchTimeout` to a positive number (of milliseconds) in a version of Vim (or Neovim) that supports timers.

The autocommand and mappings that currently call `loupe#hlmatch` (highlighting the match under the cursor) will also call `loupe#hlsearch`, which sets `'hlsearch'` and schedules a timer to deactivate it. The callback that handles deactivation only does so for the most recent timer, so multiple `n` jumps, for example, extend the life of `'hlsearch'`.

### Notes

I initially tried to implement this using `:nohlsearch` rather than manipulating the `'hlsearch'` user option, but Vim saves and restores the highlight state when calling and returning from user functions, so `:nohlsearch` was useless. Given the nature of this feature, manipulating `'hlsearch'` seems pretty reasonable.

I suppose it might be nice to make the highlight under the cursor transient as well, but I haven't implemented that yet.