### PR TITLE
Ensure E802|E803 is caught regardless of 'iskeyword'

### DIFF
--- a/autoload/loupe/private.vim
+++ b/autoload/loupe/private.vim
@@ -81,7 +81,7 @@ function! loupe#private#clear_highlight() abort
   if exists('w:loupe_hlmatch')
     try
       call matchdelete(w:loupe_hlmatch)
-    catch /\v<(E802|E803)>/
+    catch /\v(E802|E803)/
       " https://github.com/wincent/loupe/issues/1
     finally
       unlet w:loupe_hlmatch


### PR DESCRIPTION
The catch block was using '<>' to match E803 and E802 as words since the error is in the form of "E803: ....". But this is assuming the colon is not a keyword. If the colon is a keyword, such as in help files, this catch will fail.