### PR TITLE
fixes #8

### DIFF
--- a/plugin/loupe.vim
+++ b/plugin/loupe.vim
@@ -436,7 +436,10 @@ function! s:map(keys, name)
   endif
   execute 'nnoremap <silent> <Plug>(Loupe' . a:name . ')' .
         \ ' ' .
+        \ ':unsilent :norm!'.
+        \ ' ' .
         \ a:keys .
+        \ '<CR>'.
         \ 'zv' .
         \ s:center_string .
         \ ':call loupe#hlmatch()<CR>'


### PR DESCRIPTION
Fixes: https://github.com/wincent/loupe/issues/8

The side effect of this PR, is that `/\<$SEARCH\` `/?<$SEARCH\` 
will get echoed every time a loupe mapping gets called. 
As this is the default neovim (and maybe vim) behavior + that it isn't 
stated in https://github.com/wincent/loupe#overrides. 
I don't thinks this change in behavior matters. 
Having the search indices matches neovim defaults matters much more.